### PR TITLE
Differ custom xdg-shell key from upstream one

### DIFF
--- a/waylandshells/xdg-shell/xdg-shell.json
+++ b/waylandshells/xdg-shell/xdg-shell.json
@@ -1,3 +1,3 @@
 {
-    "Keys":[ "xdg-shell" ]
+    "Keys":[ "desktop-app-xdg-shell" ]
 }


### PR DESCRIPTION
I thought that Qt loads static plugins in the first place, but I was wrong, so custom xdg-shell integration should have a different name to be loaded